### PR TITLE
Kluster 0 6 4

### DIFF
--- a/HSTB/kluster/__main__.py
+++ b/HSTB/kluster/__main__.py
@@ -243,8 +243,7 @@ if __name__ == "__main__":  # run from command line
                     print('{}: unable to reload from {}, not a valid converted kluster dataset'.format(funcname, conv))
                     sys.exit()
                 reloaded_data.append(dat)
-            generate_new_surface(reloaded_data, max_grid_size=args.resolution, min_grid_size=args.resolution,
-                                 output_path=args.output_folder)
+            generate_new_surface(reloaded_data, resolution=args.resolution, output_path=args.output_folder)
         elif funcname == 'validate':
             output_file = os.path.join(os.path.split(args.multibeam_file)[0], 'validation_export.tif')
             validation_against_xyz88(args.multibeam_file, analysis_mode=args.analysis_mode, numplots=args.number_of_pings,

--- a/HSTB/kluster/__version__.py
+++ b/HSTB/kluster/__version__.py
@@ -1,2 +1,2 @@
-VERSION = (0, 6, 3)
+VERSION = (0, 6, 4)
 __version__ = '.'.join(map(str, VERSION))

--- a/HSTB/kluster/backends/_zarr.py
+++ b/HSTB/kluster/backends/_zarr.py
@@ -84,9 +84,9 @@ class ZarrBackend(BaseBackend):
             attributes = {}
         time_array = self._autodetermine_times(data, time_array, append_dim)
         zarr_path = self._get_zarr_path(dataset_name, sys_id)
-        data_indices, final_size = self._get_zarr_indices(zarr_path, time_array, append_dim)
+        data_indices, final_size, push_forward = self._get_zarr_indices(zarr_path, time_array, append_dim)
         chunks = self._get_chunk_sizes(dataset_name)
-        fpths = distrib_zarr_write(zarr_path, data, attributes, chunks, data_indices, final_size, self.client,
+        fpths = distrib_zarr_write(zarr_path, data, attributes, chunks, data_indices, final_size, push_forward, self.client,
                                    skip_dask=skip_dask, show_progress=self.show_progress,
                                    write_in_parallel=self.parallel_write)
         return zarr_path, fpths
@@ -116,8 +116,6 @@ def _get_indices_dataset_notexist(input_time_arrays):
     -------
     list
         list of [start,end] indexes for the indices of input_time_arrays
-    int
-        number of values to write, only used for the entirely outside option
     """
 
     running_total = 0
@@ -125,18 +123,27 @@ def _get_indices_dataset_notexist(input_time_arrays):
     for input_time in input_time_arrays:
         write_indices.append([0 + running_total, len(input_time) + running_total])
         running_total += len(input_time)
-    return write_indices, running_total
+    return write_indices
 
 
 def _get_indices_dataset_exists(input_time_arrays: list, zarr_time: zarr.Array):
     """
+    I am so sorry for whomever finds this.  I had this 'great' idea a while ago to concatenate all the multibeam
+    lines into daily datasets.  Overall this has been a great thing, except for the sorting.  We have to figure out
+    how to assemble daily datasets from lines applied in any order imaginable, with overlap and all kinds of things.
+    This function should provide the indices that allow this to happen.
+
     build the indices for where the input_time_arrays fit within the existing zarr_time.  We have three ways to proceed
     within this function:
     1. input time arrays are entirely within the existing zarr_time, we build a numpy array of indices that describe
     where the input_time_arrays will overwrite the zarr_time
     2. input time arrays are entirely outside the existing zarr_time, we just build a 2 element list describing the
     start and end index to append the data to zarr_time
-    3 input time arrays are only partially within zarr_time, this is not allowed
+    3 input time arrays are before and might overlap existing data, we build a 2 element list starting with zero
+    describing the start and end index and return a push_forward value, letting us know how much the zarr data
+    needs to be pushed forward.  If there is overlap, the last index is a numpy array of indices.
+    4 input time arrays are after and might overlap existing data, we build a 2 element list starting with the
+    index of the start of overlap.  If there is overlap, the last index is a numpy array of indices.
 
     Parameters
     ----------
@@ -150,26 +157,53 @@ def _get_indices_dataset_exists(input_time_arrays: list, zarr_time: zarr.Array):
     list
         list of either [start,end] indexes or numpy arrays for the indices of input_time_arrays in zarr_time
     int
-        number of values to write, only used for the entirely outside option
+        how many values need to be inserted to make room for this new data at the beginning of the zarr rootgroup
     """
+
     running_total = 0
+    push_forward = 0
     write_indices = []
+    # time arrays must be in order in case you have to do the 'partly in datastore' workaround
+    input_time_arrays.sort(key=lambda x: x[0])
+    min_zarr_time =  zarr_time[0]
+    zarr_time_len = len(zarr_time)
     for input_time in input_time_arrays:
+        input_time_len = len(input_time)
         input_is_in_zarr = np.isin(input_time, zarr_time)
+        if isinstance(input_time, xr.DataArray):
+            input_time = input_time.values
         if input_is_in_zarr.any():  # this input array is at least partly in this datastore already
             if not input_is_in_zarr.all():  # this input array is only partly in this datastore
-                raise NotImplementedError(
-                    'get_write_indices_zarr: processed data is only partly within the existing zarr dataset, must be entirely within or without')
+                starter_indices = np.full_like(input_time, -1)  # -1 for values that are outside the existing values
+                inside_indices = search_not_sorted(zarr_time, input_time[input_is_in_zarr])
+                starter_indices[input_is_in_zarr] = inside_indices
+                count_outside = len(starter_indices) - len(inside_indices)
+                if starter_indices[-1] == -1:  # this input_time contains times after the existing values
+                    max_inside_index = inside_indices[-1]
+                    if max_inside_index + 1 != zarr_time_len:
+                        raise NotImplementedError('_get_indices_dataset_exists: data provided that partially overlaps with the end of the existing dataset, but has a gap')
+
+                    # now add in a range starting with the last index for all values outside the zarr time range
+                    starter_indices[~input_is_in_zarr] = np.arange(max_inside_index + 1, max_inside_index + count_outside + 1)
+                    running_total += count_outside
+                else:  # this input_time contains times before the existing values
+                    if np.min(np.abs(starter_indices)) != 0:
+                        raise NotImplementedError('_get_indices_dataset_exists: data provided that partially overlaps with the beginning of the existing dataset, but has a gap')
+                    starter_indices = np.arange(input_time_len + running_total)
+                    push_forward += count_outside
+                write_indices.append(starter_indices)
             else:
                 # input data is entirely within the existing zarr data, the input_time is going to be sorted, but the zarr
                 # time will be in the order of lines received and saved to disk.  Have to get indices of input_time in zarr_time
-                if isinstance(input_time, xr.DataArray):
-                    input_time = input_time.values
-                write_indices.append(search_not_sorted(zarr_time, input_time))
+                write_indices.append(search_not_sorted(zarr_time, input_time) + push_forward)
         else:  # zarr datastore exists, but this data is not in it.  Append to the existing datastore
-            write_indices.append([len(zarr_time) + running_total, len(zarr_time) + len(input_time) + running_total])
-            running_total += len(input_time)
-    return write_indices, running_total
+            if input_time[0] < min_zarr_time:  # data is before existing data, have to push existing data up
+                write_indices.append([running_total, input_time_len + running_total])
+                push_forward += input_time_len
+            else:  # data is after existing data, just tack it on
+                write_indices.append([zarr_time_len + running_total, zarr_time_len + input_time_len + running_total])
+            running_total += input_time_len
+    return write_indices, push_forward
 
 
 def get_write_indices_zarr(output_pth: str, input_time_arrays: list, index_dim='time'):
@@ -199,21 +233,23 @@ def get_write_indices_zarr(output_pth: str, input_time_arrays: list, index_dim='
         write indices to use to write the input_time_arrays to the zarr datastore at outputpth
     int
         final size of the rootgroup after the write, needed to resize zarr to the appropriate length
+    int
+        how many values need to be inserted to make room for this new data at the beginning of the zarr rootgroup
     """
 
     zarr_time = np.array([])
     mintimes = [float(i.min()) for i in input_time_arrays]
     if not (np.diff(mintimes) > 0).all():  # input arrays are not time sorted
         raise NotImplementedError('get_write_indices_zarr: input arrays are out of order in time')
-
+    push_forward = 0
     if os.path.exists(output_pth):
         rootgroup = zarr.open(output_pth, mode='r')  # only opens if the path exists
         zarr_time = rootgroup[index_dim]
-        write_indices, running_total = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+        write_indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
     else:  # datastore doesn't exist, we just return the write indices equal to the shape of the input arrays
-        write_indices, running_total = _get_indices_dataset_notexist(input_time_arrays)
+        write_indices = _get_indices_dataset_notexist(input_time_arrays)
     final_size = np.max([write_indices[-1][-1], len(zarr_time)])
-    return write_indices, final_size
+    return write_indices, final_size, push_forward
 
 
 def search_not_sorted(base: np.ndarray, search_array: np.ndarray):
@@ -664,8 +700,40 @@ class ZarrWrite:
                 finalsize if dims_of_arrays[var][1].index(x) == timaxis else x for x in dims_of_arrays[var][1])
         return timaxis, timlength, startingshp
 
+    def _push_existing_data_forward(self, variable_name: str, dims_of_arrays: dict, timaxis: int, push_forward: int, starting_size: int):
+        """
+        If the user is trying to write data that comes before the existing data in the time dimension, we need to push
+        the existing data up to make room, after resizing to the total size.  This allows us to then write the new data
+        prior to the existing data.
+
+        Parameters
+        ----------
+        variable_name
+            variable name in the zarr rootgroup
+        dims_of_arrays
+            where keys are array names and values list of dims/shape.  Example: 'beampointingangle': [['time', 'sector', 'beam'], (5000, 3, 400)]
+        timaxis
+            index of the time dimension
+        push_forward
+            how many values need to be inserted to make room for this new data at the beginning of the zarr rootgroup
+        starting_size
+            size of the array on disk before we resized to make room
+        """
+
+        data_range = slice(0, starting_size)
+        data_chunk_idx = tuple(data_range if dims_of_arrays[variable_name][1].index(i) == timaxis else slice(0, i) for i in
+                               dims_of_arrays[variable_name][1])
+        final_location_range = slice(push_forward, starting_size + push_forward)
+        loc_chunk_idx = tuple(final_location_range if dims_of_arrays[variable_name][1].index(i) == timaxis else slice(0, i) for i in
+                              dims_of_arrays[variable_name][1])
+        empty_range = slice(0, push_forward)
+        empty_chunk_idx = tuple(empty_range if dims_of_arrays[variable_name][1].index(i) == timaxis else slice(0, i) for i in
+                                dims_of_arrays[variable_name][1])
+        self.rootgroup[variable_name][loc_chunk_idx] = self.rootgroup[variable_name][data_chunk_idx]
+        self.rootgroup[variable_name][empty_chunk_idx] = self.rootgroup[variable_name].fill_value
+
     def _write_existing_rootgroup(self, xarr: xr.Dataset, data_loc_copy: Union[list, np.ndarray], var_name: str, dims_of_arrays: dict,
-                                  chunksize: tuple, timlength: int, timaxis: int, startingshp: tuple):
+                                  chunksize: tuple, timlength: int, timaxis: int, startingshp: tuple, push_forward: int):
         """
         A slightly different operation than _write_new_dataset_rootgroup.  To write to an existing rootgroup array,
         we use the data_loc as an index and create a new zarr array from the xarray Dataarray.  The data_loc is only
@@ -691,13 +759,18 @@ class ZarrWrite:
         startingshp
             desired shape for the rootgroup array, might be modified later for total beams if necessary.  if finalsize
             is None (the case when this is not the first write in a set of distributed writes) this is still returned but not used.
+        push_forward
+            how many values need to be inserted to make room for this new data at the beginning of the zarr rootgroup
         """
 
         # array to be written
         xarr_data = xarr[var_name].values
         if startingshp is not None:
             startingshp = self._write_adjust_max_beams(startingshp)
+            starting_size = self.rootgroup[var_name].shape[0]
             self.rootgroup[var_name].resize(startingshp)
+            if push_forward is not None:
+                self._push_existing_data_forward(var_name, dims_of_arrays, timaxis, push_forward, starting_size)
 
         if isinstance(data_loc_copy, list):  # [start index, end index]
             # the last write will often be less than the block size.  This is allowed in the zarr store, but we
@@ -752,7 +825,8 @@ class ZarrWrite:
         newarr[:] = xarr[var_name].values
         newarr.resize(startingshp)
 
-    def write_to_zarr(self, xarr: xr.Dataset, attrs: dict, dataloc: Union[list, np.ndarray], finalsize: int = None):
+    def write_to_zarr(self, xarr: xr.Dataset, attrs: dict, dataloc: Union[list, np.ndarray], finalsize: int = None,
+                      push_forward: int = None):
         """
         Take the input xarray Dataset and write each variable as arrays in a zarr rootgroup.  Write the attributes out
         to the rootgroup as well.  Dataloc determines the index the incoming data is written to.  A new write might
@@ -771,6 +845,8 @@ class ZarrWrite:
         finalsize
             optional, int, if provided will resize zarr to the expected final size after all writes have been
             performed.  (We need to resize the zarr for that expected size before writing)
+        push_forward
+            how many values need to be inserted to make room for this new data at the beginning of the zarr rootgroup
 
         Returns
         -------
@@ -802,10 +878,10 @@ class ZarrWrite:
             if var in self.zarr_array_names:
                 if finalsize is not None:  # appending data, first write contains the final shape of the data
                     self._write_existing_rootgroup(xarr, data_loc_copy, var, dims_of_arrays, chunksize, timlength,
-                                                   timaxis, startingshp)
+                                                   timaxis, startingshp, push_forward)
                 else:
                     self._write_existing_rootgroup(xarr, data_loc_copy, var, dims_of_arrays, chunksize, timlength,
-                                                   timaxis, None)
+                                                   timaxis, None, None)
             else:
                 self._write_new_dataset_rootgroup(xarr, var, dims_of_arrays, chunksize, startingshp)
 
@@ -815,7 +891,7 @@ class ZarrWrite:
 
 
 def zarr_write(zarr_path: str, xarr: xr.Dataset, attrs: dict, desired_chunk_shape: dict, dataloc: Union[list, np.ndarray],
-               append_dim: str = 'time', finalsize: int = None):
+               append_dim: str = 'time', finalsize: int = None, push_forward: int = None):
     """
     Convenience function for writing with ZarrWrite
 
@@ -837,6 +913,8 @@ def zarr_write(zarr_path: str, xarr: xr.Dataset, attrs: dict, desired_chunk_shap
     finalsize
         optional, if provided will resize zarr to the expected final size after all writes have been performed.  (We
         need to resize the zarr for that expected size before writing)
+    push_forward
+        how many values need to be inserted to make room for this new data at the beginning of the zarr rootgroup
 
     Returns
     -------
@@ -845,12 +923,13 @@ def zarr_write(zarr_path: str, xarr: xr.Dataset, attrs: dict, desired_chunk_shap
     """
 
     zw = ZarrWrite(zarr_path, desired_chunk_shape, append_dim=append_dim)
-    zarr_path = retry_call(zw.write_to_zarr, (xarr, attrs, dataloc), {'finalsize': finalsize}, exceptions=(PermissionError,))
+    zarr_path = retry_call(zw.write_to_zarr, (xarr, attrs, dataloc), {'finalsize': finalsize, 'push_forward': push_forward},
+                           exceptions=(PermissionError,))
     return zarr_path
 
 
 def distrib_zarr_write(zarr_path: str, xarrays: list, attributes: dict, chunk_sizes: dict, data_locs: list,
-                       finalsize: int, client: Client, append_dim: str = 'time',
+                       finalsize: int, push_forward: int, client: Client, append_dim: str = 'time',
                        write_in_parallel: bool = False, skip_dask: bool = False, show_progress: bool = True):
     """
     A function for using the ZarrWrite class to write data to disk.  xarr and attrs are written to the datastore at
@@ -875,6 +954,8 @@ def distrib_zarr_write(zarr_path: str, xarrays: list, attributes: dict, chunk_si
         or np.array([4,5,6,7,1,2...]) for when data might not be continuous and we need to use a boolean mask
     finalsize
         the final size of the time dimension of the written data, we resize the zarr to this size on the first write
+    push_forward
+        how many values need to be inserted to make room for this new data at the beginning of the zarr rootgroup
     client
         dask.distributed.Client, the client we are submitting the tasks to
     append_dim
@@ -899,13 +980,13 @@ def distrib_zarr_write(zarr_path: str, xarrays: list, attributes: dict, chunk_si
         for cnt, arr in enumerate(xarrays):
             if cnt == 0:
                 futs = [zarr_write(zarr_path, arr, attributes, chunk_sizes, data_locs[cnt],
-                        append_dim=append_dim, finalsize=finalsize)]
+                        append_dim=append_dim, finalsize=finalsize, push_forward=push_forward)]
             else:
                 futs.append([zarr_write(zarr_path, xarrays[cnt], None, chunk_sizes, data_locs[cnt],
                              append_dim=append_dim)])
     else:
         futs = [client.submit(zarr_write, zarr_path, xarrays[0], attributes, chunk_sizes, data_locs[0],
-                              append_dim=append_dim, finalsize=finalsize)]
+                              append_dim=append_dim, finalsize=finalsize, push_forward=push_forward)]
         if show_progress:
             progress(futs, multi=False)
         wait(futs)

--- a/HSTB/kluster/fqpr_convenience.py
+++ b/HSTB/kluster/fqpr_convenience.py
@@ -917,6 +917,7 @@ def xyz_from_allfile(filname: str):
     ys = ys[cntrsorted]
     dpths = dpths[cntrsorted]
     cntrs = cntrs[cntrsorted]
+    pfil.close()
 
     return xs, ys, dpths, tms, cntrs
 
@@ -985,6 +986,7 @@ def xyz_from_kmallfile(filname: str):
     ys = ys[cntrsorted]
     dpths = dpths[cntrsorted]
     cntrs = cntrs[cntrsorted]
+    km.closeFile()
 
     return xs, ys, dpths, tms, cntrs
 

--- a/HSTB/kluster/fqpr_generation.py
+++ b/HSTB/kluster/fqpr_generation.py
@@ -193,7 +193,7 @@ class Fqpr(ZarrBackend):
             if True, will open zarr datastore without Dask synchronizer object
         """
 
-        self.navigation = reload_zarr_records(self.navigation_path, skip_dask, sort_by='time')
+        self.navigation = reload_zarr_records(self.navigation_path, skip_dask)
 
     def construct_crs(self, epsg: str = None, datum: str = 'NAD83', projected: bool = True, vert_ref: str = None):
         """

--- a/HSTB/kluster/fqpr_generation.py
+++ b/HSTB/kluster/fqpr_generation.py
@@ -2706,10 +2706,11 @@ class Fqpr(ZarrBackend):
 
         rnav = slice_xarray_by_dim(self.multibeam.raw_nav, 'time', start_time=start_time, end_time=end_time)
         # get the nearest nav time to the start + sample, to get downsampled rate
-        first_idx = int(np.abs(rnav.time - (rnav.time[0] + sample)).argmin())
+        navtime = rnav.time.values
+        first_idx = int(np.abs(navtime - (navtime[0] + sample)).argmin())
         if first_idx == 0:  # sample provided is less than the existing frequency
             first_idx = 1
-        idxs = np.arange(0, len(rnav.time), first_idx)
+        idxs = np.arange(0, len(navtime), first_idx)
         sampl_nav = rnav.isel(time=idxs)
 
         return sampl_nav.latitude, sampl_nav.longitude

--- a/HSTB/kluster/fqpr_intelligence.py
+++ b/HSTB/kluster/fqpr_intelligence.py
@@ -1795,7 +1795,11 @@ def intel_process(filname: Union[str, list], outfold: str = None, coord_system: 
 
     project = FqprProject(is_gui=False)
     if outfold:
-        project._setup_new_project(outfold)
+        potential_project_file = os.path.join(outfold, 'kluster_project.json')
+        if os.path.exists(potential_project_file):
+            project.open_project(potential_project_file)
+        else:
+            project._setup_new_project(outfold)
     intel = FqprIntel(project)
 
     settings = {'use_epsg': use_epsg, 'epsg': epsg, 'use_coord': not use_epsg, 'coord_system': coord_system,
@@ -1846,7 +1850,11 @@ def intel_process_service(folder_path: str, is_recursive: bool = True, outfold: 
     # consider daemonizing this at some point: https://daemoniker.readthedocs.io/en/latest/index.html
     project = FqprProject(is_gui=False)
     if outfold:
-        project._setup_new_project(outfold)
+        potential_project_file = os.path.join(outfold, 'kluster_project.json')
+        if os.path.exists(potential_project_file):
+            project.open_project(potential_project_file)
+        else:
+            project._setup_new_project(outfold)
     intel = FqprIntel(project)
 
     settings = {'use_epsg': use_epsg, 'epsg': epsg, 'use_coord': not use_epsg, 'coord_system': coord_system,

--- a/HSTB/kluster/fqpr_intelligence.py
+++ b/HSTB/kluster/fqpr_intelligence.py
@@ -441,8 +441,6 @@ class FqprIntel(LoggerClass):
                 elif len(action) > 1:
                     raise ValueError('Multibeam actions found with the same destinations, {}'.format(destination))
             else:
-                if not os.path.isdir(destination):  # destination is not an existing fqpr instance, but the name of a new one
-                    destination = os.path.join(self.project.return_project_folder(), destination)
                 newaction = fqpr_actions.build_multibeam_action(destination, line_list, self.project.client, self.general_settings)
                 self.action_container.add_action(newaction)
 
@@ -1804,9 +1802,9 @@ def intel_process(filname: Union[str, list], outfold: str = None, coord_system: 
                 'vert_ref': vert_ref, 'parallel_write': parallel_write, 'vdatum_directory': vdatum_directory}
     intel.set_settings(settings)
 
-    if os.path.isdir(filname):
-        filname = [os.path.join(filname, f) for f in os.listdir(filname)]
-    elif isinstance(filname, str):
+    if isinstance(filname, str):
+        if os.path.isdir(filname):
+            filname = [os.path.join(filname, f) for f in os.listdir(filname)]
         filname = [filname]
     for f in filname:
         updated_type, new_data, new_project = intel.add_file(f)

--- a/HSTB/kluster/fqpr_intelligence.py
+++ b/HSTB/kluster/fqpr_intelligence.py
@@ -1523,11 +1523,13 @@ def gather_multibeam_info(multibeam_file: str):
         aread = par3.AllRead(multibeam_file)
         start_end = aread.fast_read_start_end_time()
         serialnums = aread.fast_read_serial_number()
+        aread.close()
     elif fileext == '.kmall':
         mtype = 'kongsberg_kmall'
         km = kmall.kmall(multibeam_file)
         start_end = km.fast_read_start_end_time()
         serialnums = km.fast_read_serial_number()
+        km.closeFile()
     else:
         raise IOError('File ({}) is not a valid multibeam file'.format(multibeam_file))
     info_data = OrderedDict({'file_path': basic['file_path'], 'type': mtype,

--- a/HSTB/kluster/fqpr_project.py
+++ b/HSTB/kluster/fqpr_project.py
@@ -388,7 +388,6 @@ class FqprProject:
             self.fqpr_instances[relpath] = fq
             self.fqpr_attrs[relpath] = get_attributes_from_fqpr(fq, include_mode=False)
             self.regenerate_fqpr_lines(relpath)
-
             for callback in self._project_observers:
                 callback(True)
             print('Successfully added {}'.format(pth))

--- a/HSTB/kluster/fqpr_project.py
+++ b/HSTB/kluster/fqpr_project.py
@@ -815,7 +815,7 @@ class FqprProject:
                         fq_day = datetime.fromtimestamp(fqpr_instance.multibeam.raw_ping[0].time.values[0], tz=timezone.utc)
                         if fq_day.timetuple().tm_yday != same_day_as.timetuple().tm_yday:
                             continue
-                    out_path = fqpr_path
+                    out_path = self.absolute_path_from_relative(fqpr_path)
                     out_instance = fqpr_instance
                     matches += 1
         if matches > 1:

--- a/HSTB/kluster/gui/dialog_about.py
+++ b/HSTB/kluster/gui/dialog_about.py
@@ -52,8 +52,9 @@ except:
     gdalvers = 'not found'
 
 try:
-    from qgis.utils import Qgis
-    qgisvers = Qgis.QGIS_VERSION
+    from qgis.core import Qgis as _tempqgis
+    qgisvers = _tempqgis.QGIS_VERSION
+    del _tempqgis
 except:
     qgisvers = 'not found'
 

--- a/HSTB/kluster/gui/dialog_about.py
+++ b/HSTB/kluster/gui/dialog_about.py
@@ -1,5 +1,4 @@
-from HSTB.kluster.gui.backends._qt import QtGui, QtCore, QtWidgets, Signal
-
+from HSTB.kluster.gui.backends._qt import QtGui, QtCore, QtWidgets, Signal, qgis_enabled
 
 try:
     from HSTB.kluster import __version__ as klustervers
@@ -52,6 +51,12 @@ try:
 except:
     gdalvers = 'not found'
 
+try:
+    from qgis.utils import Qgis
+    qgisvers = Qgis.QGIS_VERSION
+except:
+    qgisvers = 'not found'
+
 
 class AboutDialog(QtWidgets.QDialog):
     """
@@ -94,6 +99,11 @@ class AboutDialog(QtWidgets.QDialog):
         self.leftlayout.addWidget(self.vyper_label)
         self.vyper_data = QtWidgets.QLabel('{}'.format(vypervers))
         self.rightlayout.addWidget(self.vyper_data)
+
+        self.qgis_label = QtWidgets.QLabel('QGIS Version:')
+        self.leftlayout.addWidget(self.qgis_label)
+        self.qgis_data = QtWidgets.QLabel('{}'.format(qgisvers))
+        self.rightlayout.addWidget(self.qgis_data)
 
         self.dask_label = QtWidgets.QLabel('Dask Version:')
         self.leftlayout.addWidget(self.dask_label)

--- a/HSTB/kluster/gui/dialog_about.py
+++ b/HSTB/kluster/gui/dialog_about.py
@@ -1,5 +1,6 @@
 from HSTB.kluster.gui.backends._qt import QtGui, QtCore, QtWidgets, Signal
 
+
 try:
     from HSTB.kluster import __version__ as klustervers
     if not isinstance(klustervers, str):

--- a/HSTB/kluster/gui/kluster_main.py
+++ b/HSTB/kluster/gui/kluster_main.py
@@ -360,7 +360,6 @@ class KlusterMain(QtWidgets.QMainWindow):
         add_surface: optional, str, path to new surface to add
         remove_surface: optional, str, path to existing surface to hide
         surface_layer_name: optional, str, name of the layer of the surface to add or hide
-
         """
 
         self.project_tree.refresh_project(proj=self.project)

--- a/HSTB/kluster/gui/kluster_main.py
+++ b/HSTB/kluster/gui/kluster_main.py
@@ -514,7 +514,6 @@ class KlusterMain(QtWidgets.QMainWindow):
         self.project.remove_surface(pth, relative_path=True)
         self.project_tree.refresh_project(self.project)
 
-
     def no_threads_running(self):
         """
         Simple check to see if any of the available processes are running.  Maybe in the future we want to allow

--- a/HSTB/kluster/gui/kluster_main.py
+++ b/HSTB/kluster/gui/kluster_main.py
@@ -1635,6 +1635,7 @@ def main():
             app.setPrefixPath(os.getcwd(), True)
             app.setPluginPath(plugin_dir)
         app.initQgis()
+        # print(app.showSettings())
     else:
         try:  # pyside2
             app = QtWidgets.QApplication()

--- a/HSTB/kluster/misc/kluster_main.spec
+++ b/HSTB/kluster/misc/kluster_main.spec
@@ -39,6 +39,13 @@ qgis_data_files = [(fil, "qgis_plugins") for fil in qgis_dlls]
 qgis_data_files += [(os.path.join(pydro_env, 'Library', 'bin', 'exiv2.dll'), ".")]
 qgis_data_files += [(os.path.join(pydro_env, 'Library', 'bin', 'expat.dll'), ".")]
 
+# these appear to be necessary for the WMS layers to work, removing them breaks this functionality in kluster
+qgis_data_files += [(os.path.join(pydro_env, 'Library', 'resources', 'qgis.db'), "resources")]
+qgis_data_files += [(os.path.join(pydro_env, 'Library', 'resources', 'qgis_global_settings.ini'), "resources")]
+qgis_data_files += [(os.path.join(pydro_env, 'Library', 'resources', 'spatialite.db'), "resources")]
+qgis_data_files += [(os.path.join(pydro_env, 'Library', 'resources', 'srs.db'), "resources")]
+qgis_data_files += [(os.path.join(pydro_env, 'Library', 'resources', 'symbology-style.xml'), "resources")]
+
 data_files += qgis_data_files
 for fil in data_files:
     assert os.path.exists(fil[0])

--- a/HSTB/kluster/script_tests.py
+++ b/HSTB/kluster/script_tests.py
@@ -47,7 +47,7 @@ for cnt, dset in enumerate(datasets_w_sbets):
     fq = perform_all_processing(dset, navfiles=[sbet], outfold=os.path.join(outputdir, fldernames[cnt]), coord_system='NAD83',
                                 vert_ref='ellipse', errorfiles=[smrmsg], logfiles=[logf], weekstart_year=yr,
                                 weekstart_week=wk, override_datum=dat)
-    generate_new_surface(fq, resolution=2.0, output_path=os.path.join(outputdir, fldernames[cnt]))
+    generate_new_surface(fq, resolution=8.0, output_path=os.path.join(outputdir, fldernames[cnt]))
     # fq.export_pings_to_file()
 
 sbet = r"C:\collab\dasktest\data_dir\ra_mbes\2801_em2040\pospac\035_sbet.out"
@@ -102,7 +102,7 @@ km.FID.seek(SKMOffsets[0])
 dg = km.read_EMdgmSKM()
 tme = dg['sample']['KMdefault']['dgtime']
 roll = dg['sample']['KMdefault']['roll_deg']
-
+km.closeFile()
 plt.plot(tme)
 
 ############################## accuracy tests ###################################
@@ -460,7 +460,7 @@ from HSTB.drivers import par3
 spike_file = 'D:\\falkor\\FK181005\\0041_20181010_223414_FK181005_EM710.all'
 ad = par3.AllRead(spike_file)
 recs = ad.sequential_read_records()
-
+ad.close()
 
 fq = convert_multibeam(r'D:\\falkor\\FK181005\\0041_20181010_223414_FK181005_EM710.all')
 fq.multibeam.raw_nav.latitude.plot()

--- a/HSTB/kluster/script_tests.py
+++ b/HSTB/kluster/script_tests.py
@@ -436,3 +436,19 @@ bg = generate_new_surface([fqone, fqtwo], resolution=16.0)
 bg.remove_points('em710_241_03_17_2020_0')
 bg.grid(resolution=16.0)
 bg.plot()
+
+
+################################################################
+
+from HSTB.kluster.rotations import return_mounting_rotation_matrix, combine_rotation_matrix, \
+    return_attitude_rotation_matrix
+from HSTB.kluster.fqpr_convenience import reload_data, generate_new_surface
+from HSTB.kluster.xarray_helpers import interp_across_chunks, reform_nan_array, stack_nan_array
+
+fq = reload_data(r"C:\Users\eyou1\Downloads\em2040_40224_02_15_2021")
+leverarm = [0.0416, 2.3490, 5.6210]
+
+txatt = interp_across_chunks(fq.multibeam.raw_att, fq.multibeam.raw_ping[0].time.values)
+tx_att_times, tx_attitude_rotation = return_attitude_rotation_matrix(txatt)
+ans = (tx_attitude_rotation.data @ np.float32(leverarm)).compute()[:, 2]
+

--- a/HSTB/kluster/script_tests.py
+++ b/HSTB/kluster/script_tests.py
@@ -457,36 +457,11 @@ ans = (tx_attitude_rotation.data @ np.float32(leverarm)).compute()[:, 2]
 from HSTB.kluster.fqpr_convenience import convert_multibeam
 from HSTB.drivers import par3
 
-data = []
-chnks = [['D:\\falkor\\FK181005\\0023_20181014_193617_FK181005_EM710.all', 0, 85414]]
-for chnk in chnks:
-    fil, offset, endpt = chnk
-    ar = par3.AllRead(fil, start_ptr=offset, end_ptr=endpt)
-    data.append(ar.sequential_read_records())
+spike_file = 'D:\\falkor\\FK181005\\0041_20181010_223414_FK181005_EM710.all'
+ad = par3.AllRead(spike_file)
+recs = ad.sequential_read_records()
 
 
-ar = par3.AllRead(r"D:\falkor\FK181005\0029_20181010_071015_FK181005_EM710.all")
-data = ar.sequential_read_records()
-
-
-
-from HSTB.kluster.fqpr_project import FqprProject
-project = FqprProject(is_gui=False)
-project.open_project(r"D:\falkor\FK181005_processed\kluster_project.json")
-
-
-from HSTB.kluster.fqpr_convenience import reload_data
-fq = reload_data(r"D:\falkor\FK181005_processed\em710_225_10_06_2018")
-
-import xarray as xr
-from psutil import virtual_memory
-startmem = virtual_memory().used
-data = xr.open_zarr(r"D:\falkor\FK181005_processed\em302_105_10_06_2018\attitude.zarr", synchronizer=None, mask_and_scale=False, decode_coords=False, decode_times=False, decode_cf=False, concat_characters=False)
-afterload_mem = virtual_memory().used - startmem
-ans = data.sortby('time')
-aftersort_mem = virtual_memory().used - startmem
-print('Without sort: {}'.format(afterload_mem))
-print('With sort: {}'.format(aftersort_mem))
-
-
-
+fq = convert_multibeam(r'D:\\falkor\\FK181005\\0041_20181010_223414_FK181005_EM710.all')
+fq.multibeam.raw_nav.latitude.plot()
+fq.multibeam.raw_nav.longitude.plot()

--- a/HSTB/kluster/script_tests.py
+++ b/HSTB/kluster/script_tests.py
@@ -462,6 +462,6 @@ ad = par3.AllRead(spike_file)
 recs = ad.sequential_read_records()
 ad.close()
 
-fq = convert_multibeam(r'D:\\falkor\\FK181005\\0041_20181010_223414_FK181005_EM710.all')
+fq = convert_multibeam(r"C:\collab\dasktest\data_dir\EM2040c_NRT2\0650_20180711_151518.all")
 fq.multibeam.raw_nav.latitude.plot()
 fq.multibeam.raw_nav.longitude.plot()

--- a/HSTB/kluster/script_tests.py
+++ b/HSTB/kluster/script_tests.py
@@ -452,3 +452,18 @@ txatt = interp_across_chunks(fq.multibeam.raw_att, fq.multibeam.raw_ping[0].time
 tx_att_times, tx_attitude_rotation = return_attitude_rotation_matrix(txatt)
 ans = (tx_attitude_rotation.data @ np.float32(leverarm)).compute()[:, 2]
 
+#############################################################
+
+from HSTB.kluster.fqpr_convenience import convert_multibeam
+from HSTB.drivers import par3
+
+data = []
+chnks = [['D:\\falkor\\FK181005\\0023_20181014_193617_FK181005_EM710.all', 0, 85414]]
+for chnk in chnks:
+    fil, offset, endpt = chnk
+    ar = par3.AllRead(fil, start_ptr=offset, end_ptr=endpt)
+    data.append(ar.sequential_read_records())
+
+
+ar = par3.AllRead(r"D:\falkor\FK181005\0001_20181006_075912_FK181005_EM710.all")
+data = ar.sequential_read_records()

--- a/HSTB/kluster/script_tests.py
+++ b/HSTB/kluster/script_tests.py
@@ -465,5 +465,28 @@ for chnk in chnks:
     data.append(ar.sequential_read_records())
 
 
-ar = par3.AllRead(r"D:\falkor\FK181005\0001_20181006_075912_FK181005_EM710.all")
+ar = par3.AllRead(r"D:\falkor\FK181005\0029_20181010_071015_FK181005_EM710.all")
 data = ar.sequential_read_records()
+
+
+
+from HSTB.kluster.fqpr_project import FqprProject
+project = FqprProject(is_gui=False)
+project.open_project(r"D:\falkor\FK181005_processed\kluster_project.json")
+
+
+from HSTB.kluster.fqpr_convenience import reload_data
+fq = reload_data(r"D:\falkor\FK181005_processed\em710_225_10_06_2018")
+
+import xarray as xr
+from psutil import virtual_memory
+startmem = virtual_memory().used
+data = xr.open_zarr(r"D:\falkor\FK181005_processed\em302_105_10_06_2018\attitude.zarr", synchronizer=None, mask_and_scale=False, decode_coords=False, decode_times=False, decode_cf=False, concat_characters=False)
+afterload_mem = virtual_memory().used - startmem
+ans = data.sortby('time')
+aftersort_mem = virtual_memory().used - startmem
+print('Without sort: {}'.format(afterload_mem))
+print('With sort: {}'.format(aftersort_mem))
+
+
+

--- a/HSTB/kluster/script_tests.py
+++ b/HSTB/kluster/script_tests.py
@@ -12,7 +12,8 @@ datasets = [r'C:\collab\dasktest\data_dir\EM122_RonBrown', r'C:\collab\dasktest\
             r"C:\collab\dasktest\data_dir\from_Lund\0011_20190715_070305_MALASPINA.all", r"C:\collab\dasktest\data_dir\from_Lund\0014_20170420_014958_ShipName.all",
             r"C:\collab\dasktest\data_dir\from_Lund\0034_20171114_104317_Astrolabio.all", r"C:\collab\dasktest\data_dir\from_Lund\0090_20201202_141721_Narwhal.all",
             r"C:\collab\dasktest\data_dir\from_Lund\0154_20190530_060059_Hesperides.all", r"C:\collab\dasktest\data_dir\from_Lund\0389_20170602_094427_Astrolabio.all",
-            r"C:\collab\dasktest\data_dir\from_Lund\0681_20201102_191746_TOFINO.all", r"C:\collab\dasktest\data_dir\from_Lund\EM2040-0007-t16-20181206-095359.all"]
+            r"C:\collab\dasktest\data_dir\from_Lund\0681_20201102_191746_TOFINO.all", r"C:\collab\dasktest\data_dir\from_Lund\EM2040-0007-t16-20181206-095359.all",
+            r"C:\collab\dasktest\data_dir\from_Lund\0063_20210612_092103_MAL_EM2040MKII.kmall", r"C:\collab\dasktest\data_dir\from_Lund\0011_20210304_094901_EM2040P.kmall"]
 
 datasets_w_sbets = [r'C:\collab\dasktest\data_dir\ra_mbes\2801_em2040\mbes\2020-035',
                     r'C:\collab\dasktest\data_dir\tj_patch_test\S222_PatchTest_DN077\Raw\MBES\S222_2020_KongsbergEM710\2020-077',
@@ -35,19 +36,18 @@ outputdir = r'C:\collab\dasktest\data_dir\outputtest'
 
 fldernames = ['EM122_RonBrown', 'EM710_Rainier', 'EM2040_BHII', 'EM2040_Fairweather_SmallFile', 'EM2040c_NRT2', 'EM2040p_UNH_ASV',
               'hassler_acceptance', 'Hasslerdual', 'tj_sbet_test', 'tjacceptance', 'tjmotionlatency', 'narwhal', 'antares',
-              'malaspina', 'shipname', 'astrolabio', 'narwhal2', 'hesperides', 'astrolabio2', 'tofino', 'lund_em2040']
+              'malaspina', 'shipname', 'astrolabio', 'narwhal2', 'hesperides', 'astrolabio2', 'tofino', 'lund_em2040', 'lund_em2040_kmall',
+              'lund_em2040p']
 for cnt, dset in enumerate(datasets):
     fq = perform_all_processing(dset, outfold=os.path.join(outputdir, fldernames[cnt]), coord_system='WGS84', vert_ref='waterline')
-    # generate_new_surface(fq, resolution=2.0, output_path=os.path.join(outputdir, fldernames[cnt], 'surf.npz'))
-    # fq.export_pings_to_file(export_by_identifiers=False)
 
-fldernames = ['ra_mbes', 'tj_patch_test_710', 'tj_patch_test_2040', 'val_kmall_patch']
+fldernames = ['ra_mbes', 'tj_patch_test_710', 'tj_patch_test_2040']
 for cnt, dset in enumerate(datasets_w_sbets):
     sbet, smrmsg, logf, yr, wk, dat = sbetfils[cnt]
     fq = perform_all_processing(dset, navfiles=[sbet], outfold=os.path.join(outputdir, fldernames[cnt]), coord_system='NAD83',
                                 vert_ref='ellipse', errorfiles=[smrmsg], logfiles=[logf], weekstart_year=yr,
                                 weekstart_week=wk, override_datum=dat)
-    # generate_new_surface(fq, resolution=2.0, output_path=os.path.join(outputdir, fldernames[cnt], 'surf.npz'))
+    generate_new_surface(fq, resolution=2.0, output_path=os.path.join(outputdir, fldernames[cnt]))
     # fq.export_pings_to_file()
 
 sbet = r"C:\collab\dasktest\data_dir\ra_mbes\2801_em2040\pospac\035_sbet.out"
@@ -57,12 +57,6 @@ fq = perform_all_processing(r'C:\collab\dasktest\data_dir\ra_mbes\2801_em2040\mb
                             navfiles=[sbet], errorfiles=[errorfil], logfiles=[logf], vert_ref='ellipse',
                             outfold=r"C:\collab\dasktest\data_dir\outputtest\rambes35sbet")
 fq.export_pings_to_file()
-
-sbet = r"C:\collab\dasktest\data_dir\val_kmall_patch\sbet_Mission 1.out"
-smrmsg = r"C:\collab\dasktest\data_dir\val_kmall_patch\smrms_Mission 1.out"
-fq = perform_all_processing(r'C:\collab\dasktest\data_dir\val_kmall_patch\Fallback_2040_40_1',
-                            navfiles=[sbet], vert_ref='waterline', errorfiles=[smrmsg], weekstart_year=2019,
-                            weekstart_week=15, override_datum='WGS84')
 
 # concat test
 fq_outoforder = perform_all_processing(r"C:\collab\dasktest\data_dir\EM2040c_NRT2\0634_20180711_142125.all",

--- a/HSTB/kluster/xarray_conversion.py
+++ b/HSTB/kluster/xarray_conversion.py
@@ -2280,7 +2280,10 @@ def build_xyzrph(settdict: dict, runtime_settdict: dict, sonartype: str):
         for suffix in [['_vertical_location', '_z'], ['_along_location', '_x'],
                        ['_athwart_location', '_y']]:
             qry = pos_ident + suffix[0]
-            xyzrph[tme]['imu' + suffix[1]] = float(settdict[tme][qry])
+            try:
+                xyzrph[tme]['imu' + suffix[1]] = float(settdict[tme][qry])
+            except KeyError:
+                xyzrph[tme]['imu' + suffix[1]] = 0.0
         xyzrph[tme]['latency'] = 0.0
 
         # do the same over motion sensor (which is still the POSMV), make assumption that its one of the motion
@@ -2293,7 +2296,10 @@ def build_xyzrph(settdict: dict, runtime_settdict: dict, sonartype: str):
         #                ['_roll_angle', '_r'], ['_pitch_angle', '_p'], ['_heading_angle', '_h']]:
         for suffix in [['_roll_angle', '_r'], ['_pitch_angle', '_p'], ['_heading_angle', '_h']]:
             qry = pos_motion_ident + suffix[0]
-            xyzrph[tme]['imu' + suffix[1]] = float(settdict[tme][qry])
+            try:
+                xyzrph[tme]['imu' + suffix[1]] = float(settdict[tme][qry])
+            except KeyError:
+                xyzrph[tme]['imu' + suffix[1]] = 0.0
 
         # include waterline if it exists
         if 'waterline_vertical_location' in settdict[tme]:

--- a/HSTB/kluster/xarray_conversion.py
+++ b/HSTB/kluster/xarray_conversion.py
@@ -1026,49 +1026,24 @@ class BatchRead(ZarrBackend):
 
         self.logfile = logfile_pth
         self.initialize_log()
-
-        if self.converted_pth is None:
-            self.converted_pth = os.path.dirname(ping_pth[0])
-            self.output_folder = self.converted_pth
         if self.client is None:
             skip_dask = True
         else:
             skip_dask = False
+
+        if self.converted_pth is None:
+            self.converted_pth = os.path.dirname(ping_pth[0])
+            self.output_folder = self.converted_pth
         try:
-            self.raw_ping = [reload_zarr_records(pth, skip_dask, sort_by='time') for pth in ping_pth]
-            # interp_these = ['mode', 'modetwo', 'yawpitchstab']
-            # for variable in interp_these:
-            #     if variable in finalarr:
-            #         empty_str = np.where(finalarr[variable] == '')[0]
-            #         if empty_str.any():
-            #             print('Found empty block of {} parameters'.format(interp_these))
-            #             finalarr[variable].load()
-            #             print(finalarr[variable])
-            #             groups_empty = np.split(empty_str, np.where(np.diff(empty_str) != 1)[0] + 1)
-            #             for gp in groups_empty:
-            #                 try:  # fill with the value previous to the empty chunk
-            #                     fill_with = finalarr[variable][gp[0] - 1]
-            #                 except IndexError:  # fill with the value after the empty chunk
-            #                     try:
-            #                         fill_with = finalarr[variable][gp[-1] + 1]
-            #                     except IndexError:
-            #                         print('Found no value to replace empty chunk')
-            #                         continue
-            #                 if fill_with:
-            #                     finalarr[variable][gp] = fill_with
-            #                     print(finalarr.time.values[gp[0]], finalarr.time.values[gp[-1]])
+            self.raw_ping = [reload_zarr_records(pth, skip_dask) for pth in ping_pth]
         except ValueError:
             self.logger.error('Unable to read from {}'.format(ping_pth))
 
         if self.converted_pth is None:
             self.converted_pth = os.path.dirname(attitude_pth)
             self.output_folder = self.converted_pth
-        if self.client is None:
-            skip_dask = True
-        else:
-            skip_dask = False
         try:
-            self.raw_att = reload_zarr_records(attitude_pth, skip_dask, sort_by='time')
+            self.raw_att = reload_zarr_records(attitude_pth, skip_dask)
             self.raw_att = self.raw_att.isel(time=np.unique(self.raw_att.time, return_index=True)[1])
         except (ValueError, AttributeError):
             self.logger.error('Unable to read from {}'.format(attitude_pth))
@@ -1076,12 +1051,8 @@ class BatchRead(ZarrBackend):
         if self.converted_pth is None:
             self.converted_pth = os.path.dirname(navigation_pth)
             self.output_folder = self.converted_pth
-        if self.client is None:
-            skip_dask = True
-        else:
-            skip_dask = False
         try:
-            self.raw_nav = reload_zarr_records(navigation_pth, skip_dask, sort_by='time')
+            self.raw_nav = reload_zarr_records(navigation_pth, skip_dask)
             self.raw_nav = self.raw_nav.isel(time=np.unique(self.raw_nav.time, return_index=True)[1])
         except (ValueError, AttributeError):
             self.logger.error('Unable to read from {}'.format(navigation_pth))

--- a/HSTB/kluster/xarray_helpers.py
+++ b/HSTB/kluster/xarray_helpers.py
@@ -496,13 +496,21 @@ def slice_xarray_by_dim(arr: Union[xr.Dataset, xr.DataArray], dimname: str = 'ti
     if start_time is not None:
         # just using the sel causes a huge memory drain, using the numpy method does not, for some reason
         # nearest_start = float(arr[dimname].sel(time=start_time, method='nearest'))
-        nearest_start = float(arr[dimname][(np.abs(arr[dimname] - start_time)).argmin()])
+        try:  # if arr is an xarray object (it should always be)
+            nearest_idx = np.argmin((np.abs(arr[dimname] - start_time)).data)
+        except:
+            nearest_idx = np.argmin((np.abs(arr[dimname] - start_time)))
+        nearest_start = float(arr[dimname][nearest_idx])
     else:
         nearest_start = float(arr[dimname][0])
 
     if end_time is not None:
         # nearest_end = float(arr[dimname].sel(time=end_time, method='nearest'))
-        nearest_end = float(arr[dimname][(np.abs(arr[dimname] - end_time)).argmin()])
+        try:
+            nearest_idx = np.argmin((np.abs(arr[dimname] - end_time)).data)
+        except:
+            nearest_idx = np.argmin((np.abs(arr[dimname] - end_time)))
+        nearest_end = float(arr[dimname][nearest_idx])
     else:
         nearest_end = float(arr[dimname][-1])
 

--- a/HSTB/kluster/xarray_helpers.py
+++ b/HSTB/kluster/xarray_helpers.py
@@ -494,12 +494,15 @@ def slice_xarray_by_dim(arr: Union[xr.Dataset, xr.DataArray], dimname: str = 'ti
         return arr
 
     if start_time is not None:
-        nearest_start = float(arr[dimname].sel(time=start_time, method='nearest'))
+        # just using the sel causes a huge memory drain, using the numpy method does not, for some reason
+        # nearest_start = float(arr[dimname].sel(time=start_time, method='nearest'))
+        nearest_start = float(arr[dimname][(np.abs(arr[dimname] - start_time)).argmin()])
     else:
         nearest_start = float(arr[dimname][0])
 
     if end_time is not None:
-        nearest_end = float(arr[dimname].sel(time=end_time, method='nearest'))
+        # nearest_end = float(arr[dimname].sel(time=end_time, method='nearest'))
+        nearest_end = float(arr[dimname][(np.abs(arr[dimname] - end_time)).argmin()])
     else:
         nearest_end = float(arr[dimname][-1])
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kluster
+# kluster 
 
 [![Build Status](https://travis-ci.com/noaa-ocs-hydrography/kluster.svg?branch=master)](https://travis-ci.com/noaa-ocs-hydrography/kluster)
 [![example workflow](https://github.com/noaa-ocs-hydrography/kluster/workflows/build-and-test/badge.svg)](https://github.com/noaa-ocs-hydrography/kluster/actions)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,22 @@
+import os, shutil
+
 from HSTB.kluster.backends._zarr import *
 from HSTB.kluster.backends._zarr import _get_indices_dataset_exists, _get_indices_dataset_notexist, \
     _my_xarr_to_zarr_build_arraydimensions, _my_xarr_to_zarr_writeattributes
+from HSTB.kluster.xarray_helpers import reload_zarr_records
+
+
+def get_testzarr_paths():
+    new_zarr_folder = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'test_data', 'zarrtest')
+    if os.path.exists(new_zarr_folder):
+        shutil.rmtree(new_zarr_folder)
+    os.makedirs(new_zarr_folder, exist_ok=True)
+    return new_zarr_folder
+
+
+def cleanup_after_tests():
+    newzarrfolder = get_testzarr_paths()
+    shutil.rmtree(newzarrfolder)
 
 
 def test_search_not_sorted():
@@ -28,9 +44,10 @@ def test_get_write_indices_zarr_append():
     # indices are still lists of start/end index
     data_time = np.array([10, 11, 12, 13, 14])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    indices, push_forward, total_push = _get_indices_dataset_exists(input_time_arrays, zarr_time)
     assert indices == [[10, 15]]
-    assert push_forward == 0
+    assert push_forward == []
+    assert total_push == 0
 
 
 def test_get_write_indices_zarr_overwrite():
@@ -40,11 +57,12 @@ def test_get_write_indices_zarr_overwrite():
     # indices for overwrite will be an array equal to the data length, to use the zarr set coordinate selection method
     data_time = np.array([4, 5, 6, 7, 8])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    indices, push_forward, total_push = _get_indices_dataset_exists(input_time_arrays, zarr_time)
     assert len(indices) == 1
     assert np.array_equal(indices[0], np.array([4, 5, 6, 7, 8]))
     # pushforward is 0 here as we did not need to move the original data up at all
-    assert push_forward == 0
+    assert push_forward == []
+    assert total_push == 0
 
 
 def test_get_write_indices_zarr_partlycoveredafter():
@@ -53,11 +71,12 @@ def test_get_write_indices_zarr_partlycoveredafter():
     # now we make sure that when data is partly in the array, we get the correct indices to overwrite and append
     data_time = np.array([7, 8, 9, 10, 11])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    indices, push_forward, total_push = _get_indices_dataset_exists(input_time_arrays, zarr_time)
     assert len(indices) == 1
     assert np.array_equal(indices[0], np.array([7, 8, 9, 10, 11]))
     # pushforward is 0 here as we did not need to move the original data up at all
-    assert push_forward == 0
+    assert push_forward == []
+    assert total_push == 0
 
 
 def test_get_write_indices_zarr_partlycoveredprior():
@@ -66,11 +85,12 @@ def test_get_write_indices_zarr_partlycoveredprior():
     # now we make sure that when data is partly in the array, we get the correct indices to overwrite and append
     data_time = np.array([8, 9, 10, 11, 12])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    indices, push_forward, total_push = _get_indices_dataset_exists(input_time_arrays, zarr_time)
     assert len(indices) == 1
     assert np.array_equal(indices[0], np.array([0, 1, 2, 3, 4]))
     # pushforward is 2 here as we need to push the original data up two to make room
-    assert push_forward == 2
+    assert push_forward == [[0, 2]]
+    assert total_push == 2
 
 
 def test_get_write_indices_zarr_outoforder():
@@ -78,10 +98,11 @@ def test_get_write_indices_zarr_outoforder():
     zarr_time = zarr.array([5, 6, 7, 8, 9, 0, 1, 2, 3, 4])
     data_time = np.array([4, 5, 6, 7, 8])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    indices, push_forward, total_push = _get_indices_dataset_exists(input_time_arrays, zarr_time)
     assert len(indices) == 1
     assert np.array_equal(indices[0], np.array([9, 0, 1, 2, 3]))
-    assert push_forward == 0
+    assert push_forward == []
+    assert total_push == 0
 
 
 def test_xarr_to_zarr_writeattributes():
@@ -154,7 +175,7 @@ def test_zarr_write_append():
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)
 
     data_arr2 = np.array([10, 11, 12, 13, 14])
-    indices, push_forward = _get_indices_dataset_exists([data_arr2], zw.rootgroup['time'])
+    indices, push_forward, total_push = _get_indices_dataset_exists([data_arr2], zw.rootgroup['time'])
 
     dataset = xr.Dataset({'data': (['time'], data_arr2), 'data2': (['time'], data_arr2)}, coords={'time': data_arr2})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=15)
@@ -177,7 +198,7 @@ def test_zarr_write_overwrite():
 
     data_arr2 = np.array([3, 4, 5, 6, 7])
     new_data = np.array([999, 999, 999, 999, 999])
-    indices, push_forward = _get_indices_dataset_exists([data_arr2], zw.rootgroup['time'])
+    indices, push_forward, total_push = _get_indices_dataset_exists([data_arr2], zw.rootgroup['time'])
 
     dataset = xr.Dataset({'data': (['time'], new_data), 'data2': (['time'], new_data)}, coords={'time': data_arr2})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)
@@ -189,7 +210,7 @@ def test_zarr_write_overwrite():
 
 
 def test_zarr_write_prior_overlap():
-    # for when data being written is both partly within existing data and outside existing data
+    # for when data being written is both partly within existing data and prior to existing data
     zw = ZarrWrite(None, desired_chunk_shape={'time': (10,), 'data2': (10,), 'data': (10,)})
     zw.rootgroup = zarr.group()
 
@@ -200,13 +221,45 @@ def test_zarr_write_prior_overlap():
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=20)
 
     data_arr2 = [np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]), np.array([20, 21, 22, 23, 24, 25, 26, 27, 28, 29])]
-    new_data = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29])
-    indices, push_forward = _get_indices_dataset_exists(data_arr2, zw.rootgroup['time'])
+    indices, push_forward, total_push = _get_indices_dataset_exists(data_arr2, zw.rootgroup['time'])
 
-    dataset2 = xr.Dataset({'data': (['time'], new_data), 'data2': (['time'], new_data)}, coords={'time': np.concatenate(data_arr2)})
-    zw.write_to_zarr(dataset2, None, dataloc=indices[0], finalsize=30, push_forward=push_forward)
+    for cnt, arr in enumerate(data_arr2):
+        if cnt == 0:
+            fsize = 30
+        else:
+            fsize = None
+        dataset2 = xr.Dataset({'data': (['time'], arr), 'data2': (['time'], arr)}, coords={'time': arr})
+        zw.write_to_zarr(dataset2, None, dataloc=indices[cnt], finalsize=fsize, push_forward=push_forward)
 
     expected_answer = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39])
+    assert np.array_equal(zw.rootgroup['data'], expected_answer)
+    assert np.array_equal(zw.rootgroup['data2'], expected_answer)
+    assert np.array_equal(zw.rootgroup['time'], expected_answer)
+
+
+def test_zarr_write_later_overlap():
+    # for when data being written is both partly within existing data and later than existing data
+    zw = ZarrWrite(None, desired_chunk_shape={'time': (10,), 'data2': (10,), 'data': (10,)})
+    zw.rootgroup = zarr.group()
+
+    data_arr = np.arange(20, 40, 1)
+    indices = _get_indices_dataset_notexist([data_arr])
+
+    dataset = xr.Dataset({'data': (['time'], data_arr), 'data2': (['time'], data_arr)}, coords={'time': data_arr})
+    zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=20)
+
+    data_arr2 = [np.array([30, 31, 32, 33, 34, 35, 36, 37, 38, 39]), np.array([40, 41, 42, 43, 44, 45, 46, 47, 48, 49])]
+    indices, push_forward, total_push = _get_indices_dataset_exists(data_arr2, zw.rootgroup['time'])
+
+    for cnt, arr in enumerate(data_arr2):
+        if cnt == 0:
+            fsize = 30
+        else:
+            fsize = None
+        dataset2 = xr.Dataset({'data': (['time'], arr), 'data2': (['time'], arr)}, coords={'time': arr})
+        zw.write_to_zarr(dataset2, None, dataloc=indices[cnt], finalsize=fsize, push_forward=push_forward)
+
+    expected_answer = np.array([20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49])
     assert np.array_equal(zw.rootgroup['data'], expected_answer)
     assert np.array_equal(zw.rootgroup['data2'], expected_answer)
     assert np.array_equal(zw.rootgroup['time'], expected_answer)
@@ -223,7 +276,7 @@ def test_zarr_write_merge():
     dataset = xr.Dataset({'data': (['time'], data_arr)}, coords={'time': data_arr})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)
 
-    indices, push_forward = _get_indices_dataset_exists([data_arr], zw.rootgroup['time'])
+    indices, push_forward, total_push = _get_indices_dataset_exists([data_arr], zw.rootgroup['time'])
 
     dataset = xr.Dataset({'data2': (['time'], data_arr)}, coords={'time': data_arr})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)
@@ -231,3 +284,139 @@ def test_zarr_write_merge():
     assert np.array_equal(zw.rootgroup['data'], data_arr)
     assert np.array_equal(zw.rootgroup['data2'], data_arr)
     assert np.array_equal(zw.rootgroup['time'], data_arr)
+
+
+def _return_basic_datasets(start: int, end: int):
+    dataset_name = 'ping'
+    sysid = '123'
+    datasets = []
+    dataset_time_arrays = []
+    attributes = {'test_attribute': 'abc'}
+    for i in range(start, end):
+        data_arr = np.arange(i * 10, (i * 10) + 10)
+        data2_arr = np.random.uniform(-1, 1, (10, 400))
+        beam_arr = np.arange(400)
+        dataset = xr.Dataset({'counter': (['time'], data_arr), 'beampointingangle': (['time', 'beam'], data2_arr)},
+                             coords={'time': data_arr, 'beam': beam_arr})
+        datasets.append(dataset)
+        dataset_time_arrays.append(data_arr)
+    return dataset_name, datasets, dataset_time_arrays, attributes, sysid
+
+
+def test_zarr_backend_newdata():
+    # write actual data to disk in the following tests.  This test illustrates writing data to a new data store
+    zarr_folder = get_testzarr_paths()
+    zw = ZarrBackend(zarr_folder)
+    dataset_name, datasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(0, 3)
+    zarr_path, _ = zw.write(dataset_name, datasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    xdataset = reload_zarr_records(zarr_path, skip_dask=True)
+
+    assert np.array_equal(xdataset.counter.values, np.arange(30))
+    assert np.array_equal(xdataset.time.values, np.arange(30))
+    assert np.array_equal(xdataset.beam.values, np.arange(400))
+    assert np.array_equal(xdataset.beampointingangle.values, np.concatenate([d.beampointingangle for d in datasets]))
+    assert xdataset.attrs['test_attribute'] == 'abc'
+    cleanup_after_tests()
+
+
+def test_zarr_backend_overwrite():
+    # write new data to disk
+    zarr_folder = get_testzarr_paths()
+    zw = ZarrBackend(zarr_folder)
+    dataset_name, datasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(0, 4)
+    zarr_path, _ = zw.write(dataset_name, datasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    # now build data inside the existing data
+    dataset_name, newdatasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(1, 3)
+    zarr_path, _ = zw.write(dataset_name, newdatasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    xdataset = reload_zarr_records(zarr_path, skip_dask=True)
+
+    assert np.array_equal(xdataset.counter.values, np.arange(40))
+    assert np.array_equal(xdataset.time.values, np.arange(40))
+    assert np.array_equal(xdataset.beam.values, np.arange(400))
+    expectedangle = np.concatenate([datasets[0].beampointingangle, newdatasets[0].beampointingangle, newdatasets[1].beampointingangle, datasets[3].beampointingangle])
+    assert np.array_equal(xdataset.beampointingangle.values, expectedangle)
+    assert xdataset.attrs['test_attribute'] == 'abc'
+    cleanup_after_tests()
+
+
+def test_zarr_backend_partial_before():
+    # write new data to disk
+    zarr_folder = get_testzarr_paths()
+    zw = ZarrBackend(zarr_folder)
+    dataset_name, datasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(3, 7)
+    zarr_path, _ = zw.write(dataset_name, datasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    # now build data partially before and inside the existing dataset
+    dataset_name, newdatasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(2, 4)
+    zarr_path, _ = zw.write(dataset_name, newdatasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    xdataset = reload_zarr_records(zarr_path, skip_dask=True)
+
+    assert np.array_equal(xdataset.counter.values, np.arange(20, 70))
+    assert np.array_equal(xdataset.time.values, np.arange(20, 70))
+    assert np.array_equal(xdataset.beam.values, np.arange(400))
+    expectedangle = np.concatenate([newdatasets[0].beampointingangle, newdatasets[1].beampointingangle, datasets[1].beampointingangle, datasets[2].beampointingangle, datasets[3].beampointingangle])
+    assert np.array_equal(xdataset.beampointingangle.values, expectedangle)
+    assert xdataset.attrs['test_attribute'] == 'abc'
+    cleanup_after_tests()
+
+
+def test_zarr_backend_partial_after():
+    # write new data to disk
+    zarr_folder = get_testzarr_paths()
+    zw = ZarrBackend(zarr_folder)
+    dataset_name, datasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(3, 7)
+    zarr_path, _ = zw.write(dataset_name, datasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    # now build data partially after and inside the existing dataset
+    dataset_name, newdatasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(6, 8)
+    zarr_path, _ = zw.write(dataset_name, newdatasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    xdataset = reload_zarr_records(zarr_path, skip_dask=True)
+
+    assert np.array_equal(xdataset.counter.values, np.arange(30, 80))
+    assert np.array_equal(xdataset.time.values, np.arange(30, 80))
+    assert np.array_equal(xdataset.beam.values, np.arange(400))
+    expectedangle = np.concatenate([datasets[0].beampointingangle, datasets[1].beampointingangle, datasets[2].beampointingangle, newdatasets[0].beampointingangle, newdatasets[1].beampointingangle])
+    assert np.array_equal(xdataset.beampointingangle.values, expectedangle)
+    assert xdataset.attrs['test_attribute'] == 'abc'
+    cleanup_after_tests()
+
+
+def test_zarr_backend_fully_before():
+    # write new data to disk
+    zarr_folder = get_testzarr_paths()
+    zw = ZarrBackend(zarr_folder)
+    dataset_name, datasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(3, 7)
+    zarr_path, _ = zw.write(dataset_name, datasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    # now build data fully before the existing data
+    dataset_name, newdatasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(1, 3)
+    zarr_path, _ = zw.write(dataset_name, newdatasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    xdataset = reload_zarr_records(zarr_path, skip_dask=True)
+
+    assert np.array_equal(xdataset.counter.values, np.arange(10, 70))
+    assert np.array_equal(xdataset.time.values, np.arange(10, 70))
+    assert np.array_equal(xdataset.beam.values, np.arange(400))
+    expectedangle = np.concatenate([newdatasets[0].beampointingangle, newdatasets[1].beampointingangle,
+                                    datasets[0].beampointingangle, datasets[1].beampointingangle, datasets[2].beampointingangle,
+                                    datasets[3].beampointingangle])
+    assert np.array_equal(xdataset.beampointingangle.values, expectedangle)
+    assert xdataset.attrs['test_attribute'] == 'abc'
+    cleanup_after_tests()
+
+
+def test_zarr_backend_fully_after():
+    # write new data to disk
+    zarr_folder = get_testzarr_paths()
+    zw = ZarrBackend(zarr_folder)
+    dataset_name, datasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(3, 7)
+    zarr_path, _ = zw.write(dataset_name, datasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    # now build data fully before the existing data
+    dataset_name, newdatasets, dataset_time_arrays, attributes, sysid = _return_basic_datasets(7, 9)
+    zarr_path, _ = zw.write(dataset_name, newdatasets, dataset_time_arrays, attributes, skip_dask=True, sys_id=sysid)
+    xdataset = reload_zarr_records(zarr_path, skip_dask=True)
+
+    assert np.array_equal(xdataset.counter.values, np.arange(30, 90))
+    assert np.array_equal(xdataset.time.values, np.arange(30, 90))
+    assert np.array_equal(xdataset.beam.values, np.arange(400))
+    expectedangle = np.concatenate([datasets[0].beampointingangle, datasets[1].beampointingangle, datasets[2].beampointingangle,
+                                    datasets[3].beampointingangle, newdatasets[0].beampointingangle, newdatasets[1].beampointingangle])
+    assert np.array_equal(xdataset.beampointingangle.values, expectedangle)
+    assert xdataset.attrs['test_attribute'] == 'abc'
+    cleanup_after_tests()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -17,9 +17,8 @@ def test_get_write_indices_zarr_create():
     # indices should be a list of start index, end index for each array in the list
     data_time = np.array([1, 2, 3, 4, 5])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, running_total = _get_indices_dataset_notexist(input_time_arrays)
+    indices = _get_indices_dataset_notexist(input_time_arrays)
     assert indices == [[0, 5]]
-    assert running_total == 5
 
 
 def test_get_write_indices_zarr_append():
@@ -29,9 +28,9 @@ def test_get_write_indices_zarr_append():
     # indices are still lists of start/end index
     data_time = np.array([10, 11, 12, 13, 14])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, running_total = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
     assert indices == [[10, 15]]
-    assert running_total == 5
+    assert push_forward == 0
 
 
 def test_get_write_indices_zarr_overwrite():
@@ -41,24 +40,48 @@ def test_get_write_indices_zarr_overwrite():
     # indices for overwrite will be an array equal to the data length, to use the zarr set coordinate selection method
     data_time = np.array([4, 5, 6, 7, 8])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, running_total = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
     assert len(indices) == 1
     assert np.array_equal(indices[0], np.array([4, 5, 6, 7, 8]))
-    # running_total is 0 here as we did not add any new values, the size remains the same
-    assert running_total == 0
+    # pushforward is 0 here as we did not need to move the original data up at all
+    assert push_forward == 0
 
 
-def test_get_write_indices_zarr_partlycovered():
+def test_get_write_indices_zarr_partlycoveredafter():
     # let zarr_time represent the time dimension of the data that is on disk for our test
     zarr_time = zarr.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    # now we make sure that when data is partly in the array, we get a not implemented
+    # now we make sure that when data is partly in the array, we get the correct indices to overwrite and append
     data_time = np.array([7, 8, 9, 10, 11])
     input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    try:
-        indices, running_total = _get_indices_dataset_exists(input_time_arrays, zarr_time)
-        assert False
-    except NotImplementedError:
-        assert True
+    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    assert len(indices) == 1
+    assert np.array_equal(indices[0], np.array([7, 8, 9, 10, 11]))
+    # pushforward is 0 here as we did not need to move the original data up at all
+    assert push_forward == 0
+
+
+def test_get_write_indices_zarr_partlycoveredprior():
+    # let zarr_time represent the time dimension of the data that is on disk for our test
+    zarr_time = zarr.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+    # now we make sure that when data is partly in the array, we get the correct indices to overwrite and append
+    data_time = np.array([8, 9, 10, 11, 12])
+    input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
+    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    assert len(indices) == 1
+    assert np.array_equal(indices[0], np.array([0, 1, 2, 3, 4]))
+    # pushforward is 2 here as we need to push the original data up two to make room
+    assert push_forward == 2
+
+
+def test_get_write_indices_zarr_outoforder():
+    # now check to make sure this all works when the already written data is out of time order
+    zarr_time = zarr.array([5, 6, 7, 8, 9, 0, 1, 2, 3, 4])
+    data_time = np.array([4, 5, 6, 7, 8])
+    input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
+    indices, push_forward = _get_indices_dataset_exists(input_time_arrays, zarr_time)
+    assert len(indices) == 1
+    assert np.array_equal(indices[0], np.array([9, 0, 1, 2, 3]))
+    assert push_forward == 0
 
 
 def test_xarr_to_zarr_writeattributes():
@@ -93,17 +116,6 @@ def test_xarr_to_zarr_writeattributes():
     assert rootgroup.attrs['test4'] == {'line1': ['name', 123, 456], 'line2': ['nametwo', 345, 457]}
 
 
-def test_get_write_indices_zarr_outoforder():
-    # now check to make sure this all works when the already written data is out of time order
-    zarr_time = zarr.array([5, 6, 7, 8, 9, 0, 1, 2, 3, 4])
-    data_time = np.array([4, 5, 6, 7, 8])
-    input_time_arrays = [xr.DataArray(data_time, coords={'time': data_time}, dims=['time'])]
-    indices, running_total = _get_indices_dataset_exists(input_time_arrays, zarr_time)
-    assert len(indices) == 1
-    assert np.array_equal(indices[0], np.array([9, 0, 1, 2, 3]))
-    assert running_total == 0
-
-
 def test_build_arraydimensions():
     ping_time = np.arange(100)
     data_arr = np.arange(100)
@@ -119,7 +131,7 @@ def test_zarr_write_create():
     zw.rootgroup = zarr.group()
 
     data_arr = np.arange(100)
-    indices, running_total = _get_indices_dataset_notexist([data_arr])
+    indices = _get_indices_dataset_notexist([data_arr])
 
     dataset = xr.Dataset({'data': (['time'], data_arr), 'data2': (['time'], data_arr)}, coords={'time': data_arr})
     zw.write_to_zarr(dataset, {'testthis': 123}, dataloc=indices[0], finalsize=100)
@@ -136,13 +148,13 @@ def test_zarr_write_append():
     zw.rootgroup = zarr.group()
 
     data_arr = np.arange(10)
-    indices, running_total = _get_indices_dataset_notexist([data_arr])
+    indices = _get_indices_dataset_notexist([data_arr])
 
     dataset = xr.Dataset({'data': (['time'], data_arr), 'data2': (['time'], data_arr)}, coords={'time': data_arr})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)
 
     data_arr2 = np.array([10, 11, 12, 13, 14])
-    indices, running_total = _get_indices_dataset_exists([data_arr2], zw.rootgroup['time'])
+    indices, push_forward = _get_indices_dataset_exists([data_arr2], zw.rootgroup['time'])
 
     dataset = xr.Dataset({'data': (['time'], data_arr2), 'data2': (['time'], data_arr2)}, coords={'time': data_arr2})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=15)
@@ -158,14 +170,14 @@ def test_zarr_write_overwrite():
     zw.rootgroup = zarr.group()
 
     data_arr = np.arange(10)
-    indices, running_total = _get_indices_dataset_notexist([data_arr])
+    indices = _get_indices_dataset_notexist([data_arr])
 
     dataset = xr.Dataset({'data': (['time'], data_arr), 'data2': (['time'], data_arr)}, coords={'time': data_arr})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)
 
     data_arr2 = np.array([3, 4, 5, 6, 7])
     new_data = np.array([999, 999, 999, 999, 999])
-    indices, running_total = _get_indices_dataset_exists([data_arr2], zw.rootgroup['time'])
+    indices, push_forward = _get_indices_dataset_exists([data_arr2], zw.rootgroup['time'])
 
     dataset = xr.Dataset({'data': (['time'], new_data), 'data2': (['time'], new_data)}, coords={'time': data_arr2})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)
@@ -176,18 +188,42 @@ def test_zarr_write_overwrite():
     assert np.array_equal(zw.rootgroup['time'], data_arr)
 
 
+def test_zarr_write_prior_overlap():
+    # for when data being written is both partly within existing data and outside existing data
+    zw = ZarrWrite(None, desired_chunk_shape={'time': (10,), 'data2': (10,), 'data': (10,)})
+    zw.rootgroup = zarr.group()
+
+    data_arr = np.arange(20, 40, 1)
+    indices = _get_indices_dataset_notexist([data_arr])
+
+    dataset = xr.Dataset({'data': (['time'], data_arr), 'data2': (['time'], data_arr)}, coords={'time': data_arr})
+    zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=20)
+
+    data_arr2 = [np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]), np.array([20, 21, 22, 23, 24, 25, 26, 27, 28, 29])]
+    new_data = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29])
+    indices, push_forward = _get_indices_dataset_exists(data_arr2, zw.rootgroup['time'])
+
+    dataset2 = xr.Dataset({'data': (['time'], new_data), 'data2': (['time'], new_data)}, coords={'time': np.concatenate(data_arr2)})
+    zw.write_to_zarr(dataset2, None, dataloc=indices[0], finalsize=30, push_forward=push_forward)
+
+    expected_answer = np.array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39])
+    assert np.array_equal(zw.rootgroup['data'], expected_answer)
+    assert np.array_equal(zw.rootgroup['data2'], expected_answer)
+    assert np.array_equal(zw.rootgroup['time'], expected_answer)
+
+
 def test_zarr_write_merge():
     # merge is for when we have an existing rootgroup, but the new dataset has a variable that is not in the rootgroup
     zw = ZarrWrite(None, desired_chunk_shape={'time': (10,), 'data2': (10,), 'data': (10,)})
     zw.rootgroup = zarr.group()
 
     data_arr = np.arange(10)
-    indices, running_total = _get_indices_dataset_notexist([data_arr])
+    indices = _get_indices_dataset_notexist([data_arr])
 
     dataset = xr.Dataset({'data': (['time'], data_arr)}, coords={'time': data_arr})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)
 
-    indices, running_total = _get_indices_dataset_exists([data_arr], zw.rootgroup['time'])
+    indices, push_forward = _get_indices_dataset_exists([data_arr], zw.rootgroup['time'])
 
     dataset = xr.Dataset({'data2': (['time'], data_arr)}, coords={'time': data_arr})
     zw.write_to_zarr(dataset, None, dataloc=indices[0], finalsize=10)

--- a/tests/test_fqpr_generation.py
+++ b/tests/test_fqpr_generation.py
@@ -188,6 +188,7 @@ def test_converted_data_content():
         totnav += rec.data['Time'].shape[0]
     assert out.multibeam.raw_nav.time.shape[0] == totnav
 
+    ad.close()
     out.close()
     out = None
 


### PR DESCRIPTION
kmall - fix for incorrectly translated detection info flag
converting multibeam files now correctly drops empty files/chunks of data that have no pings
add in .close() for the multibeam classes to clear file handler
_zarr backend - now reorders data on disk to ensure data is in order of ascending times
disable sorting/dropping duplicate times on reload to conserve memory, rely on data being in correct time order
add Help - About screen with versions
slice_xarray_by_dim no longer uses xarray sel, does it in numpy instead, this is much more memory efficient
move to np.argmin instead of daskarray.argmin() to clear deprecation warnings
fix for project return_project_folder incorrectly returning relative path
fix for intel process using isdir on non string filname
fix for intel process, will load an existing project now
fix for pyinstaller routine - will carry over the correct qgis files for loading WMS layers
