### PR TITLE
fixes after troubleshooting pyinstaller build

### DIFF
--- a/HSTB/kluster/gui/dialog_surface.py
+++ b/HSTB/kluster/gui/dialog_surface.py
@@ -164,7 +164,6 @@ class SurfaceDialog(SaveStateDialog):
         layout.addWidget(self.basic_surface_group)
         layout.addWidget(self.line_surface_checkbox)
         layout.addWidget(QtWidgets.QLabel(' '))
-        layout.addLayout(self.hlayout_zero)
         layout.addLayout(self.surf_layout)
         layout.addWidget(self.status_msg)
         layout.addLayout(self.hlayout_two)

--- a/HSTB/kluster/misc/kluster_main.spec
+++ b/HSTB/kluster/misc/kluster_main.spec
@@ -39,12 +39,14 @@ data_files = [
 	(os.path.join(klusterfolder_path, 'docbuild'), os.path.join("HSTB", "kluster", "docbuild")),
 	(os.path.join(env_base_path, 'Lib', 'site-packages', 'vispy', 'util', 'fonts'), os.path.join("vispy", "util", "fonts")),
 	(os.path.join(env_base_path, 'Library', 'bin', 'libiomp5md.dll'), "."),
-	(os.path.join(env_base_path, 'Library', 'bin', 'mkl_intel_thread.dll'), "."),
+	(os.path.join(env_base_path, 'Library', 'bin', 'mkl_intel_thread.1.dll'), "."),
     (os.path.dirname(vispy.glsl.__file__), os.path.join("vispy", "glsl")),
     (os.path.join(os.path.dirname(vispy.io.__file__), "_data"), os.path.join("vispy", "io", "_data")),
     (os.path.join(os.path.dirname(distributed.__file__)), "distributed"),
     (os.path.join(env_base_path, 'Lib', 'site-packages', 'numcodecs', 'blosc.cp38-win_amd64.pyd'), "numcodecs"),
-	(os.path.join(env_base_path, 'Lib', 'site-packages', 'numcodecs', 'compat_ext.cp38-win_amd64.pyd'), "numcodecs")
+	(os.path.join(env_base_path, 'Lib', 'site-packages', 'numcodecs', 'compat_ext.cp38-win_amd64.pyd'), "numcodecs"),
+	(os.path.join(env_base_path, 'Lib', 'site-packages', 'osgeo', '_gdal.cp38-win_amd64.pyd'), "osgeo"),
+	(os.path.join(env_base_path, 'Lib', 'site-packages', 'pyqtgraph', 'console'), os.path.join('pyqtgraph', 'console'))
 ]
 
 qgis_dlls = glob.glob(os.path.join(env_base_path, 'Library', 'plugins', '*.dll'))
@@ -61,8 +63,11 @@ qgis_data_files += [(os.path.join(env_base_path, 'Library', 'resources', 'symbol
 
 data_files += qgis_data_files
 for fil in data_files:
-    assert os.path.exists(fil[0])
-
+    try:
+        assert os.path.exists(fil[0])
+    except:
+        print('Unable to find file: {}'.format(fil[0]))
+        sys.exit()
 
 hidden_imports = [
 	"PyQt5.QtPrintSupport", 

--- a/HSTB/kluster/misc/pyinstaller_command.bat
+++ b/HSTB/kluster/misc/pyinstaller_command.bat
@@ -1,3 +1,5 @@
+REM setting env variable SETUPTOOLS_USE_DISTUTILS to resolve setuptools/xarray issue with setuptools/distutils conflict, see xarray pull request #6096 and setuptools issue #2353
+set SETUPTOOLS_USE_DISTUTILS=stdlib
 cd C:\Pydro21_Dev\NOAA\site-packages\Python38\git_repos\hstb_kluster\HSTB\kluster\misc && call C:\Pydro21_Dev\Scripts\activate Pydro38 && pyinstaller "C:\Pydro21_Dev\NOAA\site-packages\Python38\git_repos\hstb_kluster\HSTB\kluster\misc\kluster_main.spec"
 REM Gdal expects the bag_template.xml to be accessible, put it next to the executable
 echo f | xcopy /f /y "C:\Pydro21_Dev\NOAA\site-packages\Python38\git_repos\hstb_kluster\HSTB\kluster\misc\dist\kluster_main\Library\share\gdal\bag_template.xml" "C:\Pydro21_Dev\NOAA\site-packages\Python38\git_repos\hstb_kluster\HSTB\kluster\misc\dist\kluster_main\bag_template.xml"


### PR DESCRIPTION
pyinstaller not working, after troubleshooting, made the following fixes
- added os.environ['SETUPTOOLS_USE_DISTUTILS'] = 'stdlib' to the top of my kluster_main.py file to set this variable prior to importing anything that might create this distutils/setuptools conflict
- created a new osgeo folder in my pyinstaller generated kluster folder, so that running kluster_main.exe, it will find the _gdal.pyd file in the osgeo folder to make the namespace work
- created a new pyqtgraph/console folder in my pyinstaller generated kluster folder, so that running kluster_main.exe, it will find the console templates to make the namespace work
- resolved layout bug in dialog_surface that was raising warning
- fix bug with gridding workflow across selected lines/fqprs