### PR TITLE
downgrade minimal python version requirments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ DESCRIPTION = 'Distributed hydrographic multibeam processing system'
 URL = 'https://github.com/noaa-ocs-hydrography/kluster'
 EMAIL = 'eric.g.younkin@noaa.gov'
 AUTHOR = 'Eric Younkin'
-REQUIRES_PYTHON = '>=3.8.12'
+REQUIRES_PYTHON = '>=3.8.10'
 VERSION = ''
 
 # What packages are required for this module to be executed?


### PR DESCRIPTION
attempt to use python >=3.8.10 (default on ubuntu 20.04) instead of 3.8.12
Ubuntu images come with python 3.8.10 (even after a distr-upgrade) relaxing the setup.py to check for a python version `>=3.8.10` - will facilitate the installation process on ubuntu 20.04