### PR TITLE
attempt to fix call to QGIS action for linux

### DIFF
--- a/HSTB/kluster/gui/kluster_main.py
+++ b/HSTB/kluster/gui/kluster_main.py
@@ -2936,7 +2936,6 @@ class KlusterMain(QtWidgets.QMainWindow):
 
     def _action_qgis(self):
         if sys.platform == "linux":
-            qgis_executable =  "/usr/bin/qgis"
             subprocess.Popen(qgis_executable, 
                              shell=True, 
                              stdout=subprocess.PIPE, 

--- a/HSTB/kluster/gui/kluster_main.py
+++ b/HSTB/kluster/gui/kluster_main.py
@@ -22,6 +22,7 @@ from pyproj import CRS, Transformer
 import qdarkstyle
 import matplotlib.pyplot as plt
 import logging
+import subprocess
 
 from HSTB.kluster.gui import dialog_vesselview, kluster_explorer, kluster_project_tree, kluster_3dview_v2, \
     kluster_output_window, kluster_2dview, kluster_actions, kluster_monitor, dialog_daskclient, dialog_surface, \
@@ -2934,7 +2935,14 @@ class KlusterMain(QtWidgets.QMainWindow):
         widget.show()
 
     def _action_qgis(self):
-        os.startfile('qgis.exe')
+        if sys.platform == "linux":
+            qgis_executable =  "/usr/bin/qgis"
+            subprocess.Popen(qgis_executable, 
+                             shell=True, 
+                             stdout=subprocess.PIPE, 
+                             stderr=subprocess.PIPE)
+        else:
+            os.startfile('qgis.exe')
 
     def _action_file_analyzer(self):
         self._fileanalyzer = dialog_fileanalyzer.FileAnalyzerDialog(parent=self)

--- a/HSTB/kluster/gui/kluster_main.py
+++ b/HSTB/kluster/gui/kluster_main.py
@@ -2936,7 +2936,7 @@ class KlusterMain(QtWidgets.QMainWindow):
 
     def _action_qgis(self):
         if sys.platform == "linux":
-            subprocess.Popen(qgis_executable, 
+            subprocess.Popen(kluster_variables.linux_qgis_executable,
                              shell=True, 
                              stdout=subprocess.PIPE, 
                              stderr=subprocess.PIPE)

--- a/HSTB/kluster/gui/kluster_main.py
+++ b/HSTB/kluster/gui/kluster_main.py
@@ -2936,11 +2936,18 @@ class KlusterMain(QtWidgets.QMainWindow):
 
     def _action_qgis(self):
         if sys.platform == "linux":
+            print(f'Starting QGIS:  Path={kluster_variables.linux_qgis_executable}')
             subprocess.Popen(kluster_variables.linux_qgis_executable,
                              shell=True, 
                              stdout=subprocess.PIPE, 
                              stderr=subprocess.PIPE)
         else:
+            try:
+                rtn = subprocess.check_output(['where', 'qgis.exe'])
+                pth = rtn.rstrip().decode()
+            except:
+                pth = 'unknown'
+            print(f'Starting QGIS:  Path={pth}')
             os.startfile('qgis.exe')
 
     def _action_file_analyzer(self):

--- a/HSTB/kluster/kluster_variables.py
+++ b/HSTB/kluster/kluster_variables.py
@@ -44,6 +44,9 @@ last_change_buffer_size = 50
 # _qgis backend
 qgis_epsg = 4326
 
+# QGIS exacutable PATH
+qgis_executable = "/usr/bin/qgis"
+
 # generic processing
 max_beams = 400  # starting max beams in kluster (can grow beyond)
 epsg_nad83 = 6318

--- a/HSTB/kluster/kluster_variables.py
+++ b/HSTB/kluster/kluster_variables.py
@@ -41,11 +41,9 @@ rejected_flag = 2
 accepted_flag = 3
 last_change_buffer_size = 50
 
-# _qgis backend
+# qgis properties
 qgis_epsg = 4326
-
-# QGIS exacutable PATH
-qgis_executable = "/usr/bin/qgis"
+linux_qgis_executable = "/usr/bin/qgis"
 
 # generic processing
 max_beams = 400  # starting max beams in kluster (can grow beyond)


### PR DESCRIPTION
The "run QGIS" action  `os.startfile('qgis.exe')` is not available on linux - adding a call to subprocess - 

TODO: hardcoded PATH for a system wide QGIS installation (maybe this should come from a configuration setting)
