### PR TITLE
Dask error and regional settings

### DIFF
--- a/HSTB/kluster/gui/kluster_3dview_v2.py
+++ b/HSTB/kluster/gui/kluster_3dview_v2.py
@@ -1645,7 +1645,7 @@ class ThreeDWidget(QtWidgets.QWidget):
                             try:
                                 tcntrl.setText(text_value)
                             except:
-                                tcntrl.setValue(float(text_value))
+                                tcntrl.setValue(float(text_value.replace(',', '.')))
             if self.checkbox_controls:
                 for cname, ccntrl in self.checkbox_controls:
                     check_value = settings.value('{}/{}_{}'.format(self.appname, self.widgetname, cname))

--- a/HSTB/kluster/xarray_conversion.py
+++ b/HSTB/kluster/xarray_conversion.py
@@ -39,7 +39,8 @@ sonar_translator = {'ek60': [None, 'tx', 'rx', None], 'ek80': [None, 'tx', 'rx',
                     'em3002': [None, 'tx', 'rx', None], 'em2040p': [None, 'txrx', None, None],
                     'em3020': [None, 'tx', 'rx', None], 'em3020_dual': [None, 'txrx_port', 'txrx_stbd', None],
                     'me70': [None, 'txrx', None, None], '7125': [None, 'tx', 'rx', None], 't20': [None, 'tx', 'rx', None],
-                    't50': [None, 'tx', 'rx', None], 't51': [None, 'tx', 'rx', None]}
+                    't50': [None, 'tx', 'rx', None], 't51': [None, 'tx', 'rx', None],
+                    'norbitbathy': [None, 'tx', 'rx', None]}
 
 # ensure that Kluster sonar translator supports all sonar_translators in multibeam drivers
 assert all([snr in sonar_translator for snr in par_sonar_translator.keys()])

--- a/HSTB/kluster/xarray_helpers.py
+++ b/HSTB/kluster/xarray_helpers.py
@@ -593,7 +593,7 @@ def interp_across_chunks(xarr: Union[xr.Dataset, xr.DataArray], new_times: xr.Da
                                            dims=['time'])
 
     chnk_idxs, chnkwise_times = _interp_across_chunks_construct_times(xarr, new_times, dimname)
-    xarrs_chunked = [xarr.isel({dimname: slice(i, j)}).chunk(j-i,) for i, j in chnk_idxs]
+    xarrs_chunked = [xarr.isel({dimname: slice(i, j)}).chunk(int(j-i),) for i, j in chnk_idxs]
     if daskclient is None:
         interp_arrs = []
         for ct, xar in enumerate(xarrs_chunked):


### PR DESCRIPTION
I'd like to submit a PR for two small issues.

The first is related to a dask issue.

The second is related to kluster storing for the "3dview_vertexag" variable a comma instead of a dot (based on the Windows regional settings I presume) in the kluster.ini file. This lead to kluster not being able to start a second time after a new install. I'm not sure that my solution is the most appropriate, but it does the job.